### PR TITLE
Add missing tagging of ImpersonateExtension

### DIFF
--- a/src/Resources/config/impersonating.xml
+++ b/src/Resources/config/impersonating.xml
@@ -2,6 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
     <service id="Nucleos\UserAdminBundle\Twig\ImpersonateExtension">
+      <tag name="twig.extension"/>
       <argument type="service" id="router"/>
       <argument>null</argument>
       <argument type="collection"/>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Subject

The twig extension is not registered.
