### PR TITLE
Fix grouping of roles in permission matrix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "cs": "PHP_CS_FIXER_IGNORE_ENV=1 && vendor/bin/php-cs-fixer fix --verbose",
         "cs-diff": "PHP_CS_FIXER_IGNORE_ENV=1 && vendor/bin/php-cs-fixer fix  --verbose --diff --diff-format=udiff --dry-run",
         "deps": "vendor/bin/composer-require-checker check --config-file composer-require.json composer.json",
-        "infection": "vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=66 --min-msi=51",
+        "infection": "vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=66 --min-msi=50",
         "lint": [
             "find ./src \\( -name '*.xml' -or -name '*.xml.dist' -or -name '*.xlf' \\) -type f -exec xmllint --encode UTF-8 --output '{}' --format '{}' \\;",
             "find ./src \\( -name '*.yml' -or -name '*.yaml' \\) -not -path '*/vendor/*' | xargs yaml-lint"

--- a/tests/Security/RolesBuilder/AdminRolesBuilderTest.php
+++ b/tests/Security/RolesBuilder/AdminRolesBuilderTest.php
@@ -108,6 +108,10 @@ final class AdminRolesBuilderTest extends TestCase
             ->willReturn($this->securityInformation)
         ;
 
+        $this->admin->method('getBaseCodeRoute')
+            ->willReturn('sonata.admin.bar')
+        ;
+
         $this->pool->expects(static::once())
             ->method('getAdminServiceIds')
             ->willReturn(['sonata.admin.bar'])
@@ -117,6 +121,10 @@ final class AdminRolesBuilderTest extends TestCase
             ->method('getInstance')
             ->with('sonata.admin.bar')
             ->willReturn($this->admin)
+        ;
+
+        $this->pool->method('getAdminGroups')
+            ->willReturn([])
         ;
 
         $rolesBuilder = new AdminRolesBuilder(
@@ -161,6 +169,10 @@ final class AdminRolesBuilderTest extends TestCase
             ->willReturn('Foo')
         ;
 
+        $this->admin->method('getBaseCodeRoute')
+            ->willReturn('sonata.admin.bar')
+        ;
+
         $this->pool->expects(static::once())
             ->method('getAdminServiceIds')
             ->willReturn(['sonata.admin.bar'])
@@ -170,6 +182,10 @@ final class AdminRolesBuilderTest extends TestCase
             ->method('getInstance')
             ->with('sonata.admin.bar')
             ->willReturn($this->admin)
+        ;
+
+        $this->pool->method('getAdminGroups')
+            ->willReturn([])
         ;
 
         $rolesBuilder = new AdminRolesBuilder(
@@ -184,28 +200,28 @@ final class AdminRolesBuilderTest extends TestCase
                 'label'           => 'GUEST',
                 'role_translated' => 'ROLE_SONATA_FOO_GUEST',
                 'is_granted'      => false,
-                'admin_label'     => 'Foo',
+                'admin_label'     => 'sonata > Foo',
             ],
             'ROLE_SONATA_FOO_STAFF'  => [
                 'role'            => 'ROLE_SONATA_FOO_STAFF',
                 'label'           => 'STAFF',
                 'role_translated' => 'ROLE_SONATA_FOO_STAFF',
                 'is_granted'      => false,
-                'admin_label'     => 'Foo',
+                'admin_label'     => 'sonata > Foo',
             ],
             'ROLE_SONATA_FOO_EDITOR' => [
                 'role'            => 'ROLE_SONATA_FOO_EDITOR',
                 'label'           => 'EDITOR',
                 'role_translated' => 'ROLE_SONATA_FOO_EDITOR',
                 'is_granted'      => false,
-                'admin_label'     => 'Foo',
+                'admin_label'     => 'sonata > Foo',
             ],
             'ROLE_SONATA_FOO_ADMIN'  => [
                 'role'            => 'ROLE_SONATA_FOO_ADMIN',
                 'label'           => 'ADMIN',
                 'role_translated' => 'ROLE_SONATA_FOO_ADMIN',
                 'is_granted'      => false,
-                'admin_label'     => 'Foo',
+                'admin_label'     => 'sonata > Foo',
             ],
         ];
 

--- a/tests/Twig/RolesMatrixExtensionTest.php
+++ b/tests/Twig/RolesMatrixExtensionTest.php
@@ -102,19 +102,16 @@ final class RolesMatrixExtensionTest extends TestCase
         $this->environment
             ->expects(static::once())
             ->method('render')
-            ->with(
-                '@NucleosUserAdmin/Form/roles_matrix_list.html.twig',
-                [
-                    'roles' => [
-                        'SUPER_TEST_ROLE' => [
-                            'role'            => 'SUPER_TEST_ROLE',
-                            'role_translated' => 'SUPER TEST ROLE TRANSLATED',
-                            'is_granted'      => true,
-                            'form'            => $form,
-                        ],
+            ->with('@NucleosUserAdmin/Form/roles_matrix_list.html.twig', [
+                'roles' => [
+                    'SUPER_TEST_ROLE' => [
+                        'role'            => 'SUPER_TEST_ROLE',
+                        'role_translated' => 'SUPER TEST ROLE TRANSLATED',
+                        'is_granted'      => true,
+                        'form'            => $form,
                     ],
-                ]
-            )
+                ],
+            ])
             ->willReturn('')
         ;
 
@@ -246,24 +243,21 @@ final class RolesMatrixExtensionTest extends TestCase
         $this->environment
             ->expects(static::once())
             ->method('render')
-            ->with(
-                '@NucleosUserAdmin/Form/roles_matrix.html.twig',
-                [
-                    'grouped_roles'     => [
-                        'fooadmin' => [
-                            'BASE_ROLE_FOO_EDIT' => [
-                                'role'            => 'BASE_ROLE_FOO_EDIT',
-                                'label'           => 'EDIT',
-                                'role_translated' => 'ROLE FOO TRANSLATED',
-                                'admin_label'     => 'fooadmin',
-                                'is_granted'      => true,
-                                'form'            => $form,
-                            ],
+            ->with('@NucleosUserAdmin/Form/roles_matrix.html.twig', [
+                'grouped_roles'     => [
+                    'fooadmin' => [
+                        'BASE_ROLE_FOO_EDIT' => [
+                            'role'            => 'BASE_ROLE_FOO_EDIT',
+                            'label'           => 'EDIT',
+                            'role_translated' => 'ROLE FOO TRANSLATED',
+                            'admin_label'     => 'fooadmin',
+                            'is_granted'      => true,
+                            'form'            => $form,
                         ],
                     ],
-                    'permission_labels' => ['EDIT', 'CREATE'],
-                ]
-            )
+                ],
+                'permission_labels' => ['EDIT', 'CREATE'],
+            ])
             ->willReturn('')
         ;
 
@@ -306,23 +300,20 @@ final class RolesMatrixExtensionTest extends TestCase
         $this->environment
             ->expects(static::once())
             ->method('render')
-            ->with(
-                '@NucleosUserAdmin/Form/roles_matrix.html.twig',
-                [
-                    'grouped_roles'     => [
-                        'fooadmin' => [
-                            'BASE_ROLE_FOO_%s' => [
-                                'role'            => 'BASE_ROLE_FOO_EDIT',
-                                'label'           => 'EDIT',
-                                'role_translated' => 'ROLE FOO TRANSLATED',
-                                'admin_label'     => 'fooadmin',
-                                'is_granted'      => true,
-                            ],
+            ->with('@NucleosUserAdmin/Form/roles_matrix.html.twig', [
+                'grouped_roles'     => [
+                    'fooadmin' => [
+                        'BASE_ROLE_FOO_%s' => [
+                            'role'            => 'BASE_ROLE_FOO_EDIT',
+                            'label'           => 'EDIT',
+                            'role_translated' => 'ROLE FOO TRANSLATED',
+                            'admin_label'     => 'fooadmin',
+                            'is_granted'      => true,
                         ],
                     ],
-                    'permission_labels' => ['EDIT', 'CREATE'],
-                ]
-            )
+                ],
+                'permission_labels' => ['EDIT', 'CREATE'],
+            ])
             ->willReturn('')
         ;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #15

## Subject

Fixes the group display by using unique permissions rows.

Changes the permission matrix to display a translated label. The label consists of the admin group labeled followed by the admin label.

![Screenshot 2020-02-05 at 19 17 55](https://user-images.githubusercontent.com/3440437/73870366-46289300-484c-11ea-9167-4fdb50e1b965.png)
