### PR TITLE
Throw deletion event before deleting a user

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "nucleos/user-bundle": "^1.6",
+        "nucleos/user-bundle": "^1.9",
         "psr/log": "^1.0",
         "sonata-project/admin-bundle": "^3.90",
         "sonata-project/doctrine-extensions": "^1.5.1",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.5.1@257a1ca672a79dedc852be1285a7b97154646418">
+<files psalm-version="4.6.4@97fe86c4e158b5a57c5150aa5055c38b5a809aab">
   <file src="src/Action/LoginAction.php">
     <TooManyArguments occurrences="1">
       <code>dispatch</code>
@@ -14,6 +14,11 @@
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;getSubject()</code>
     </PossiblyNullArgument>
+  </file>
+  <file src="src/Controller/UserCRUDController.php">
+    <TooManyArguments occurrences="1">
+      <code>dispatch</code>
+    </TooManyArguments>
   </file>
   <file src="src/DependencyInjection/Configuration.php">
     <PossiblyUndefinedMethod occurrences="1">

--- a/src/Controller/UserCRUDController.php
+++ b/src/Controller/UserCRUDController.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the NucleosUserAdminBundle package.
+ *
+ * (c) Christian Gripp <mail@core23.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nucleos\UserAdminBundle\Controller;
+
+use Nucleos\UserBundle\Event\AccountDeletionEvent;
+use Nucleos\UserBundle\NucleosUserEvents;
+use Sonata\AdminBundle\Controller\CRUDController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @phpstan-extends CRUDController<\Nucleos\UserBundle\Model\UserInterface>
+ */
+class UserCRUDController extends CRUDController
+{
+    protected function preDelete(Request $request, $object)
+    {
+        $this->getEventDispatcher()->dispatch(new AccountDeletionEvent($object, $request), NucleosUserEvents::ACCOUNT_DELETION);
+
+        return null;
+    }
+
+    private function getEventDispatcher(): EventDispatcherInterface
+    {
+        $eventDispatcher = $this->get('event_dispatcher');
+
+        \assert($eventDispatcher instanceof EventDispatcherInterface);
+
+        return $eventDispatcher;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,6 +16,7 @@ namespace Nucleos\UserAdminBundle\DependencyInjection;
 use Nucleos\UserAdminBundle\Admin\Entity\GroupAdmin;
 use Nucleos\UserAdminBundle\Admin\Entity\UserAdmin;
 use Nucleos\UserAdminBundle\Avatar\StaticAvatarResolver;
+use Nucleos\UserAdminBundle\Controller\UserCRUDController;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -58,7 +59,7 @@ final class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('class')->cannotBeEmpty()->defaultValue(UserAdmin::class)->end()
-                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue(CRUDController::class)->end()
+                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue(UserCRUDController::class)->end()
                                 ->scalarNode('translation')->cannotBeEmpty()->defaultValue('NucleosUserAdminBundle')->end()
                             ->end()
                         ->end()

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -17,6 +17,7 @@ use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use Nucleos\UserAdminBundle\Admin\Entity\GroupAdmin;
 use Nucleos\UserAdminBundle\Admin\Entity\UserAdmin;
 use Nucleos\UserAdminBundle\Avatar\StaticAvatarResolver;
+use Nucleos\UserAdminBundle\Controller\UserCRUDController;
 use Nucleos\UserAdminBundle\DependencyInjection\Configuration;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Controller\CRUDController;
@@ -42,7 +43,7 @@ final class ConfigurationTest extends TestCase
                 'admin'                => [
                     'user'  => [
                         'class'       => UserAdmin::class,
-                        'controller'  => CRUDController::class,
+                        'controller'  => UserCRUDController::class,
                         'translation' => 'NucleosUserAdminBundle',
                     ],
                     'group' => [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Throw new `Nucleos\UserBundle\Event\AccountDeletionEvent` before deleting a single user. 

This event will not be thrown when deleting users in batch. This is a restriction of the SonataAdminBundle.


Refs: https://github.com/nucleos/NucleosUserBundle/pull/291
