### PR TITLE
Catch null error

### DIFF
--- a/src/Action/SendEmailAction.php
+++ b/src/Action/SendEmailAction.php
@@ -91,7 +91,7 @@ final class SendEmailAction
     {
         $username = $request->request->get('username');
 
-        $user = $this->userManager->findUserByUsernameOrEmail($username);
+        $user = null === $username ? null : $this->userManager->findUserByUsernameOrEmail($username);
 
         if (null === $user) {
             return new Response($this->twig->render('@NucleosUserAdmin/Admin/Security/Resetting/request.html.twig', [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Subject

Catches null error:

```

Uncaught PHP Exception TypeError: "Argument 1 passed to Nucleos\UserBundle\Model\UserManager::findUserByUsernameOrEmail() must be of the type string, null given, called in /www/htdocs/***/vendor/nucleos/user-admin-bundle/src/Action/SendEmailAction.php on line 94" at /www/htdocs/***/vendor/nucleos/user-bundle/src/Model/UserManager.php line 53


```