### PR TITLE
Drop support for PHP 7.3

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -14,14 +14,14 @@ branches:
       enforce_admins: false
       required_status_checks:
         contexts:
-          - "Coding Standards (7.4)"
-          - "Static Code Analysis (7.4)"
-          - "Test (PHP 7.3, symfony 4.4, lowest)"
-          - "Test (PHP 7.3, symfony 4.4, highest)"
+          - "Coding Standards (8)"
+          - "Static Code Analysis (8)"
           - "Test (PHP 7.4, symfony 4.4, lowest)"
           - "Test (PHP 7.4, symfony 4.4, highest)"
-          - "Code Coverage (7.4)"
-          - "Mutation Tests (7.4)"
+          - "Test (PHP 8, symfony 4.4, lowest)"
+          - "Test (PHP 8, symfony 4.4, highest)"
+          - "Code Coverage (8)"
+          - "Mutation Tests (8)"
         strict: true
 
       required_pull_request_reviews: null

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -113,6 +113,7 @@ jobs:
         php-version:
           - 7.4
           - 8.0
+          - 8.1
 
         dependencies:
           - lowest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
+          - 8.0
 
     steps:
       - name: "Checkout"
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
+          - 8.0
 
     steps:
       - name: "Checkout"
@@ -111,7 +111,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.3
           - 7.4
           - 8.0
 
@@ -132,10 +131,6 @@ jobs:
           coverage: none
           extensions: "mbstring, json, mongo"
           php-version: ${{ matrix.php-version }}
-
-      - name: "Configuration required for PHP 8.0"
-        if: matrix.php-version == '8.0'
-        run: composer config platform.php 7.4.99
 
       - name: 'Install Symfony Flex'
         run: composer global require --prefer-dist --no-progress --no-suggest --ansi symfony/flex
@@ -170,7 +165,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
+          - 8.0
 
     steps:
       - name: "Checkout"
@@ -210,7 +205,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
+          - 8.0
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "nucleos/user-bundle": "^1.9",
         "psr/log": "^1.0",

--- a/vendor-bin/tools/composer.json
+++ b/vendor-bin/tools/composer.json
@@ -20,7 +20,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.3"
+            "php": "7.4"
         }
     }
 }


### PR DESCRIPTION
Security support will end in two months: https://www.php.net/supported-versions.php