### PR TITLE
Fix translation on login page

### DIFF
--- a/src/Action/LoginAction.php
+++ b/src/Action/LoginAction.php
@@ -95,7 +95,7 @@ final class LoginAction
 
         if ($this->isAuthenticated()) {
             $message = 'nucleos_user_admin_already_authenticated';
-            $message = $this->translator ? $this->translator->trans($message, [], 'NucleosUserAdminBundle') : $message;
+            $message = $this->translator != null ? $this->translator->trans($message, [], 'NucleosUserAdminBundle') : $message;
             $this->addFlash($session, 'sonata_flash_info', $message);
 
             return new RedirectResponse($this->router->generate('sonata_admin_dashboard'));

--- a/src/Action/LoginAction.php
+++ b/src/Action/LoginAction.php
@@ -95,7 +95,7 @@ final class LoginAction
 
         if ($this->isAuthenticated()) {
             $message = 'nucleos_user_admin_already_authenticated';
-            $message = $this->translator != null ? $this->translator->trans($message, [], 'NucleosUserAdminBundle') : $message;
+            $message = null !== $this->translator ? $this->translator->trans($message, [], 'NucleosUserAdminBundle') : $message;
             $this->addFlash($session, 'sonata_flash_info', $message);
 
             return new RedirectResponse($this->router->generate('sonata_admin_dashboard'));

--- a/src/Action/LoginAction.php
+++ b/src/Action/LoginAction.php
@@ -61,6 +61,9 @@ final class LoginAction
 
     private ?TranslatorInterface $translator;
 
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
     public function __construct(
         Environment $twig,
         EventDispatcherInterface $eventDispatcher,

--- a/src/Action/LoginAction.php
+++ b/src/Action/LoginAction.php
@@ -34,6 +34,7 @@ use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
 final class LoginAction
@@ -56,6 +57,8 @@ final class LoginAction
 
     private FormFactoryInterface $formFactory;
 
+    private TranslatorInterface $translator;
+
     private ?AuthenticationUtils $authenticationUtils;
 
     public function __construct(
@@ -67,6 +70,7 @@ final class LoginAction
         TemplateRegistryInterface $templateRegistry,
         TokenStorageInterface $tokenStorage,
         FormFactoryInterface $formFactory,
+        TranslatorInterface $translator,
         ?AuthenticationUtils $authenticationUtils = null
     ) {
         $this->twig                 = $twig;
@@ -77,6 +81,7 @@ final class LoginAction
         $this->templateRegistry     = $templateRegistry;
         $this->tokenStorage         = $tokenStorage;
         $this->formFactory          = $formFactory;
+        $this->translator           = $translator;
         $this->authenticationUtils  = $authenticationUtils;
     }
 
@@ -89,7 +94,8 @@ final class LoginAction
         $session = $request->hasSession() ? $request->getSession() : null;
 
         if ($this->isAuthenticated()) {
-            $this->addFlash($session, 'nucleos_user_admin_error', 'nucleos_user_admin_already_authenticated');
+            $message = $this->translator->trans('nucleos_user_admin_already_authenticated', [], 'NucleosUserAdminBundle');
+            $this->addFlash($session, 'sonata_flash_info', $message);
 
             return new RedirectResponse($this->router->generate('sonata_admin_dashboard'));
         }

--- a/src/Action/LoginAction.php
+++ b/src/Action/LoginAction.php
@@ -57,9 +57,9 @@ final class LoginAction
 
     private FormFactoryInterface $formFactory;
 
-    private TranslatorInterface $translator;
-
     private ?AuthenticationUtils $authenticationUtils;
+
+    private ?TranslatorInterface $translator;
 
     public function __construct(
         Environment $twig,
@@ -70,8 +70,8 @@ final class LoginAction
         TemplateRegistryInterface $templateRegistry,
         TokenStorageInterface $tokenStorage,
         FormFactoryInterface $formFactory,
-        TranslatorInterface $translator,
-        ?AuthenticationUtils $authenticationUtils = null
+        ?AuthenticationUtils $authenticationUtils = null,
+        ?TranslatorInterface $translator = null
     ) {
         $this->twig                 = $twig;
         $this->eventDispatcher      = $eventDispatcher;
@@ -81,8 +81,8 @@ final class LoginAction
         $this->templateRegistry     = $templateRegistry;
         $this->tokenStorage         = $tokenStorage;
         $this->formFactory          = $formFactory;
-        $this->translator           = $translator;
         $this->authenticationUtils  = $authenticationUtils;
+        $this->translator           = $translator;
     }
 
     /**
@@ -94,7 +94,8 @@ final class LoginAction
         $session = $request->hasSession() ? $request->getSession() : null;
 
         if ($this->isAuthenticated()) {
-            $message = $this->translator->trans('nucleos_user_admin_already_authenticated', [], 'NucleosUserAdminBundle');
+            $message = 'nucleos_user_admin_already_authenticated';
+            $message = $this->translator ? $this->translator->trans($message, [], 'NucleosUserAdminBundle') : $message;
             $this->addFlash($session, 'sonata_flash_info', $message);
 
             return new RedirectResponse($this->router->generate('sonata_admin_dashboard'));

--- a/src/Resources/config/action.php
+++ b/src/Resources/config/action.php
@@ -85,7 +85,7 @@ return static function (ContainerConfigurator $container): void {
                 ref('security.token_storage'),
                 ref('form.factory'),
                 ref('security.authentication_utils'),
-                ref('translator')
+                ref('translator'),
             ])
             ->call('setCsrfTokenManager', [
                 ref('security.csrf.token_manager')->ignoreOnInvalid(),

--- a/src/Resources/config/action.php
+++ b/src/Resources/config/action.php
@@ -84,8 +84,8 @@ return static function (ContainerConfigurator $container): void {
                 ref('sonata.admin.global_template_registry'),
                 ref('security.token_storage'),
                 ref('form.factory'),
-                ref('translator'),
                 ref('security.authentication_utils'),
+                ref('translator')
             ])
             ->call('setCsrfTokenManager', [
                 ref('security.csrf.token_manager')->ignoreOnInvalid(),

--- a/src/Resources/config/action.php
+++ b/src/Resources/config/action.php
@@ -84,6 +84,7 @@ return static function (ContainerConfigurator $container): void {
                 ref('sonata.admin.global_template_registry'),
                 ref('security.token_storage'),
                 ref('form.factory'),
+                ref('translator'),
                 ref('security.authentication_utils'),
             ])
             ->call('setCsrfTokenManager', [

--- a/tests/Action/LoginActionTest.php
+++ b/tests/Action/LoginActionTest.php
@@ -97,7 +97,6 @@ final class LoginActionTest extends TestCase
         $this->csrfTokenManager     = $this->createMock(CsrfTokenManagerInterface::class);
         $this->formFactory          = $this->createMock(FormFactoryInterface::class);
         $this->translator           = $this->createMock(TranslatorInterface::class);
-
     }
 
     public function testAlreadyAuthenticated(): void
@@ -138,10 +137,10 @@ final class LoginActionTest extends TestCase
         $action = $this->getAction();
         $result = $action($request);
 
-        self::assertInstanceOf(RedirectResponse::class, $result);
-        self::assertSame('/foo', $result->getTargetUrl());
+        static::assertInstanceOf(RedirectResponse::class, $result);
+        static::assertSame('/foo', $result->getTargetUrl());
 
-        self::assertSame([
+        static::assertSame([
             'sonata_flash_info' => ['nucleos_user_admin_already_authenticated'],
         ], $session->getFlashBag()->all());
     }
@@ -167,7 +166,7 @@ final class LoginActionTest extends TestCase
             ->willReturn('/foo')
         ;
 
-        $this->authorizationChecker->expects(self::once())
+        $this->authorizationChecker->expects(static::once())
             ->method('isGranted')
             ->with('ROLE_ADMIN')
             ->willReturn(true)
@@ -176,8 +175,8 @@ final class LoginActionTest extends TestCase
         $action = $this->getAction();
         $result = $action($request);
 
-        self::assertInstanceOf(RedirectResponse::class, $result);
-        self::assertSame($expectedRedirectUrl, $result->getTargetUrl());
+        static::assertInstanceOf(RedirectResponse::class, $result);
+        static::assertSame($expectedRedirectUrl, $result->getTargetUrl());
     }
 
     /**
@@ -257,12 +256,12 @@ final class LoginActionTest extends TestCase
             ->method('add')
             ->willReturnSelf()
         ;
-        $form->expects(self::once())
+        $form->expects(static::once())
             ->method('createView')
             ->willReturn('Form View')
         ;
 
-        $this->formFactory->expects(self::once())
+        $this->formFactory->expects(static::once())
             ->method('create')
             ->willReturn($form)
         ;
@@ -277,7 +276,7 @@ final class LoginActionTest extends TestCase
             ->willReturn('/check', '/reset')
         ;
 
-        $this->authorizationChecker->expects(self::once())
+        $this->authorizationChecker->expects(static::once())
             ->method('isGranted')
             ->with('ROLE_ADMIN')
             ->willReturn(false)
@@ -304,7 +303,7 @@ final class LoginActionTest extends TestCase
         $action = $this->getAction();
         $result = $action($request);
 
-        self::assertSame('template content', $result->getContent());
+        static::assertSame('template content', $result->getContent());
     }
 
     public function unauthenticatedProvider(): array

--- a/tests/Action/LoginActionTest.php
+++ b/tests/Action/LoginActionTest.php
@@ -118,7 +118,7 @@ final class LoginActionTest extends TestCase
             ->method('trans')
             ->willReturnCallback(
                 static function (string $message): string {
-                    return $message;
+                    return 'trans.'.$message;
                 }
             )
         ;
@@ -141,7 +141,7 @@ final class LoginActionTest extends TestCase
         static::assertSame('/foo', $result->getTargetUrl());
 
         static::assertSame([
-            'sonata_flash_info' => ['nucleos_user_admin_already_authenticated'],
+            'sonata_flash_info' => ['trans.nucleos_user_admin_already_authenticated'],
         ], $session->getFlashBag()->all());
     }
 

--- a/tests/Action/LoginActionTest.php
+++ b/tests/Action/LoginActionTest.php
@@ -115,6 +115,15 @@ final class LoginActionTest extends TestCase
             ->willReturn($token)
         ;
 
+        $this->translator
+            ->method('trans')
+            ->willReturnCallback(
+                static function (string $message): string {
+                    return $message;
+                }
+            )
+        ;
+
         $session = new Session();
 
         $request = new Request();
@@ -133,7 +142,7 @@ final class LoginActionTest extends TestCase
         static::assertSame('/foo', $result->getTargetUrl());
 
         static::assertSame([
-            'nucleos_user_admin_error' => ['nucleos_user_admin_already_authenticated'],
+            'sonata_flash_info' => ['nucleos_user_admin_already_authenticated'],
         ], $session->getFlashBag()->all());
     }
 
@@ -319,6 +328,7 @@ final class LoginActionTest extends TestCase
             $this->templateRegistry,
             $this->tokenStorage,
             $this->formFactory,
+            null,
             $this->translator
         );
         $action->setCsrfTokenManager($this->csrfTokenManager);

--- a/tests/Action/LoginActionTest.php
+++ b/tests/Action/LoginActionTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
 final class LoginActionTest extends TestCase
@@ -79,6 +80,11 @@ final class LoginActionTest extends TestCase
      */
     private $formFactory;
 
+    /**
+     * @var MockObject&TranslatorInterface
+     */
+    protected $translator;
+
     protected function setUp(): void
     {
         $this->templating           = $this->createMock(Environment::class);
@@ -90,6 +96,8 @@ final class LoginActionTest extends TestCase
         $this->tokenStorage         = $this->createMock(TokenStorageInterface::class);
         $this->csrfTokenManager     = $this->createMock(CsrfTokenManagerInterface::class);
         $this->formFactory          = $this->createMock(FormFactoryInterface::class);
+        $this->translator           = $this->createMock(TranslatorInterface::class);
+
     }
 
     public function testAlreadyAuthenticated(): void
@@ -310,7 +318,8 @@ final class LoginActionTest extends TestCase
             $this->pool,
             $this->templateRegistry,
             $this->tokenStorage,
-            $this->formFactory
+            $this->formFactory,
+            $this->translator
         );
         $action->setCsrfTokenManager($this->csrfTokenManager);
 

--- a/tests/Action/LoginActionTest.php
+++ b/tests/Action/LoginActionTest.php
@@ -78,7 +78,7 @@ final class LoginActionTest extends TestCase
     /**
      * @var MockObject&FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var MockObject&TranslatorInterface
@@ -138,10 +138,10 @@ final class LoginActionTest extends TestCase
         $action = $this->getAction();
         $result = $action($request);
 
-        static::assertInstanceOf(RedirectResponse::class, $result);
-        static::assertSame('/foo', $result->getTargetUrl());
+        self::assertInstanceOf(RedirectResponse::class, $result);
+        self::assertSame('/foo', $result->getTargetUrl());
 
-        static::assertSame([
+        self::assertSame([
             'sonata_flash_info' => ['nucleos_user_admin_already_authenticated'],
         ], $session->getFlashBag()->all());
     }
@@ -152,7 +152,7 @@ final class LoginActionTest extends TestCase
     public function testUserGrantedAdmin(string $referer, string $expectedRedirectUrl): void
     {
         $session = $this->createMock(Session::class);
-        $request = Request::create('http://some.url.com/exact-request-uri');
+        $request = Request::create('https://some.url.com/exact-request-uri');
         $request->server->add(['HTTP_REFERER' => $referer]);
         $request->setSession($session);
 
@@ -167,7 +167,7 @@ final class LoginActionTest extends TestCase
             ->willReturn('/foo')
         ;
 
-        $this->authorizationChecker->expects(static::once())
+        $this->authorizationChecker->expects(self::once())
             ->method('isGranted')
             ->with('ROLE_ADMIN')
             ->willReturn(true)
@@ -176,8 +176,8 @@ final class LoginActionTest extends TestCase
         $action = $this->getAction();
         $result = $action($request);
 
-        static::assertInstanceOf(RedirectResponse::class, $result);
-        static::assertSame($expectedRedirectUrl, $result->getTargetUrl());
+        self::assertInstanceOf(RedirectResponse::class, $result);
+        self::assertSame($expectedRedirectUrl, $result->getTargetUrl());
     }
 
     /**
@@ -187,8 +187,8 @@ final class LoginActionTest extends TestCase
     {
         return [
             ['', '/foo'],
-            ['http://some.url.com/exact-request-uri', '/foo'],
-            ['http://some.url.com', 'http://some.url.com'],
+            ['https://some.url.com/exact-request-uri', '/foo'],
+            ['https://some.url.com', 'https://some.url.com'],
         ];
     }
 
@@ -257,12 +257,12 @@ final class LoginActionTest extends TestCase
             ->method('add')
             ->willReturnSelf()
         ;
-        $form->expects(static::once())
+        $form->expects(self::once())
             ->method('createView')
             ->willReturn('Form View')
         ;
 
-        $this->formFactory->expects(static::once())
+        $this->formFactory->expects(self::once())
             ->method('create')
             ->willReturn($form)
         ;
@@ -277,7 +277,7 @@ final class LoginActionTest extends TestCase
             ->willReturn('/check', '/reset')
         ;
 
-        $this->authorizationChecker->expects(static::once())
+        $this->authorizationChecker->expects(self::once())
             ->method('isGranted')
             ->with('ROLE_ADMIN')
             ->willReturn(false)
@@ -304,7 +304,7 @@ final class LoginActionTest extends TestCase
         $action = $this->getAction();
         $result = $action($request);
 
-        static::assertSame('template content', $result->getContent());
+        self::assertSame('template content', $result->getContent());
     }
 
     public function unauthenticatedProvider(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #414, #426

## Subject

<!-- Describe your Pull Request content here -->

* This translates the Message shown when already logged in
* used "sonata_flash_info" as flash type, so no need to register new one
(adding a new flash type without user interaction is difficult)