### PR TITLE
Prevent security role escalation

### DIFF
--- a/src/Admin/Model/UserAdmin.php
+++ b/src/Admin/Model/UserAdmin.php
@@ -152,9 +152,13 @@ abstract class UserAdmin extends AbstractAdmin
             ->end()
 
             ->tab('security', ['label' => 'form.group_security'])
-                ->with('groups', ['class' => 'col-md-8', 'label' => 'form.group_groups'])->end()
+                ->ifTrue($this->isGranted('ROLE_SUPER_ADMIN'))
+                    ->with('groups', ['class' => 'col-md-8', 'label' => 'form.group_groups'])->end()
+                ->ifEnd()
                 ->with('status', ['class' => 'col-md-4', 'label' => 'form.group_status'])->end()
-                ->with('roles', ['class' => 'col-md-12', 'label' => 'form.group_roles'])->end()
+                ->ifTrue($this->isGranted('ROLE_SUPER_ADMIN'))
+                    ->with('roles', ['class' => 'col-md-12', 'label' => 'form.group_roles'])->end()
+                ->ifEnd()
             ->end()
         ;
 
@@ -183,21 +187,23 @@ abstract class UserAdmin extends AbstractAdmin
                 ->with('status')
                     ->add('enabled', null, ['required' => false])
                 ->end()
-                ->with('groups')
-                    ->add('groups', ModelType::class, [
-                        'required' => false,
-                        'expanded' => true,
-                        'multiple' => true,
-                    ])
-                ->end()
-                ->with('roles')
-                    ->add('roles', RolesMatrixType::class, [
-                        'label'    => 'form.label_roles',
-                        'expanded' => true,
-                        'multiple' => true,
-                        'required' => false,
-                    ])
-                ->end()
+                ->ifTrue($this->isGranted('ROLE_SUPER_ADMIN'))
+                    ->with('groups')
+                        ->add('groups', ModelType::class, [
+                            'required' => false,
+                            'expanded' => true,
+                            'multiple' => true,
+                        ])
+                    ->end()
+                    ->with('roles')
+                        ->add('roles', RolesMatrixType::class, [
+                            'label'    => 'form.label_roles',
+                            'expanded' => true,
+                            'multiple' => true,
+                            'required' => false,
+                        ])
+                    ->end()
+                ->ifEnd()
             ->end()
         ;
     }


### PR DESCRIPTION
This is a bugfix for a high security issue.

If you have a user that has admin rights to edit (other) users, the user could assign ANY group to other users. E.g. if you have a group with super admin permissions, the user could assign itself the user group go get full admin access.

With this hotfix, only super admin users can change user groups. A more advanced bugfix is coming the next days to partial restore group assignment.